### PR TITLE
Ajoute un générateur de reporting à partir du grand livre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.pytest_cache/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# Génération de reporting à partir du grand livre
+
+Ce projet fournit un petit outil Python qui applique un **mapping de comptes** à un
+**grand livre comptable** exporté en CSV afin de produire un reporting synthétique
+de vos chiffres.
+
+## Structure du dépôt
+
+```
+gl_reporting/        # Cœur de la librairie (lecture du grand livre, mapping, reporting)
+data/                # Jeux de données d'exemple
+README.md            # Ce fichier
+```
+
+## Installation et exécution
+
+Le projet ne dépend que de la bibliothèque standard de Python 3.10+. Pour tester
+rapidement, créez un environnement virtuel puis lancez la commande suivante :
+
+```bash
+python -m gl_reporting.report \
+    --ledger data/sample_ledger.csv \
+    --mapping data/sample_mapping.csv
+```
+
+La commande affiche un tableau récapitulatif directement dans le terminal. Vous
+pouvez également générer des fichiers CSV :
+
+```bash
+python -m gl_reporting.report \
+    --ledger data/sample_ledger.csv \
+    --mapping data/sample_mapping.csv \
+    --output reporting.csv \
+    --details details.csv
+```
+
+* `reporting.csv` contiendra un tableau synthétique (catégorie / montant).
+* `details.csv` contiendra le détail de chaque écriture et la règle appliquée.
+
+## Préparer vos propres fichiers
+
+1. **Grand livre** : exportez-le en CSV avec au minimum les colonnes `account`,
+   `debit` et `credit`. Les colonnes supplémentaires comme `date`, `journal` ou
+   `libellé` sont automatiquement reconnues.
+2. **Mapping** : créez un fichier CSV avec au moins deux colonnes :
+   * `pattern` — motif au format "glob" (`70*`, `401??`, `6?32*`, ...),
+   * `category` — nom de la ligne de reporting.
+
+   Colonnes optionnelles :
+   * `label` — description libre,
+   * `sign` — `1` ou `-1` pour inverser le signe (utile pour les comptes de produits).
+
+Le moteur applique toujours la règle la plus spécifique (celle qui contient le
+moins de jokers). Les écritures non couvertes sont regroupées dans la catégorie
+« Non affecté » (personnalisable via `--default-category`).
+
+## Tests
+
+Les tests unitaires utilisent `pytest` :
+
+```bash
+pytest
+```
+
+## Aller plus loin
+
+Le code source (`gl_reporting/report.py`) peut facilement être intégré dans un
+pipeline plus large (ETL, notebook, etc.) pour automatiser la production d'un
+reporting périodique.

--- a/data/sample_ledger.csv
+++ b/data/sample_ledger.csv
@@ -1,0 +1,7 @@
+date,journal,account,description,debit,credit
+2024-01-01,VT,701100,Vente de marchandises,0,1500
+2024-01-02,VT,706000,Prestations de services,0,500
+2024-01-03,AC,606100,Achat de matières,200,0
+2024-01-04,AC,613200,Loyer,300,0
+2024-01-05,BN,512000,Encaissement client,1000,0
+2024-01-06,OD,471000,Ecriture à ventiler,100,0

--- a/data/sample_mapping.csv
+++ b/data/sample_mapping.csv
@@ -1,0 +1,7 @@
+pattern,category,label,sign
+706*,CA - Prestations,Prestations de services,-1
+70*,CA - Marchandises,Ventes de marchandises,-1
+606*,Charges - Achats,Achat de matières,1
+613*,Charges - Loyer,Loyers et locations,1
+61*,Charges - Services,Autres services externes,1
+512*,Trésorerie,Banque principale,1

--- a/gl_reporting/__init__.py
+++ b/gl_reporting/__init__.py
@@ -1,0 +1,38 @@
+"""Tools for mapping a French general ledger to management reporting lines."""
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from .ledger import LedgerEntry, LedgerFormatError, load_ledger
+from .mapping import MappingRule, MappingTable, load_mapping
+
+_REPORT_EXPORTS = {
+    "CategorisedEntry",
+    "ReportResult",
+    "aggregate_by_category",
+    "build_report",
+    "print_summary",
+    "write_details_csv",
+    "write_summary_csv",
+}
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - simple lazy import
+    if name in _REPORT_EXPORTS:
+        module = importlib.import_module(".report", __name__)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(name)
+
+
+__all__ = [
+    "LedgerEntry",
+    "LedgerFormatError",
+    "load_ledger",
+    "MappingRule",
+    "MappingTable",
+    "load_mapping",
+    *_REPORT_EXPORTS,
+]

--- a/gl_reporting/ledger.py
+++ b/gl_reporting/ledger.py
@@ -1,0 +1,154 @@
+"""Utilities for parsing a general ledger exported to CSV."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Dict, Iterable, List, Optional
+import csv
+
+
+@dataclass(frozen=True)
+class LedgerEntry:
+    """Represents a single movement in the general ledger."""
+
+    date: Optional[date]
+    journal: Optional[str]
+    account: str
+    description: Optional[str]
+    debit: Decimal
+    credit: Decimal
+
+    @property
+    def amount(self) -> Decimal:
+        """Returns the signed amount of the movement (debit - credit)."""
+
+        return self.debit - self.credit
+
+
+_HEADER_ALIASES: Dict[str, tuple[str, ...]] = {
+    "date": ("date", "Date", "DATE"),
+    "journal": ("journal", "Journal", "JOURNAL"),
+    "account": (
+        "account",
+        "compte",
+        "Compte",
+        "ACCOUNT",
+        "COMPTE",
+        "numéro de compte",
+        "numero_compte",
+    ),
+    "description": (
+        "description",
+        "libellé",
+        "libelle",
+        "Libellé",
+        "Libelle",
+        "DESCRIPTION",
+        "LIBELLE",
+    ),
+    "debit": ("debit", "Débit", "Debit", "DEBIT", "DEBITO"),
+    "credit": ("credit", "Crédit", "Credit", "CREDIT", "CREDITO"),
+}
+
+
+class LedgerFormatError(RuntimeError):
+    """Raised when the ledger CSV does not contain the expected columns."""
+
+
+def _normalize_header(field: str) -> str:
+    for normalized, aliases in _HEADER_ALIASES.items():
+        if field in aliases:
+            return normalized
+    return field.lower()
+
+
+def _map_headers(fieldnames: Iterable[str]) -> Dict[str, str]:
+    normalized: Dict[str, str] = {}
+    for name in fieldnames:
+        norm = _normalize_header(name)
+        if norm not in normalized:
+            normalized[norm] = name
+    missing = {"account", "debit", "credit"} - set(normalized)
+    if missing:
+        raise LedgerFormatError(
+            "Missing required columns in ledger: " + ", ".join(sorted(missing))
+        )
+    return normalized
+
+
+def _parse_decimal(value: str) -> Decimal:
+    cleaned = value.strip().replace(" ", "")
+    if not cleaned:
+        return Decimal("0")
+    if cleaned.count(",") > 0 and cleaned.count(".") == 0:
+        cleaned = cleaned.replace(",", ".")
+    try:
+        return Decimal(cleaned)
+    except InvalidOperation as exc:  # pragma: no cover - defensive
+        raise LedgerFormatError(f"Invalid decimal value: {value!r}") from exc
+
+
+def _parse_date(value: str) -> Optional[date]:
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    formats = ["%Y-%m-%d", "%d/%m/%Y", "%d-%m-%Y", "%d.%m.%Y"]
+    for fmt in formats:
+        try:
+            return datetime.strptime(cleaned, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def load_ledger(path: str, encoding: str = "utf-8") -> List[LedgerEntry]:
+    """Loads the ledger CSV file.
+
+    The file must at least contain the columns "account", "debit" and "credit".
+    Additional optional columns such as date, journal or description are detected
+    automatically using common French aliases ("libellé", "compte", ...).
+    """
+
+    entries: List[LedgerEntry] = []
+    with open(path, "r", encoding=encoding, newline="") as handle:
+        sample = handle.read(4096)
+        handle.seek(0)
+        try:
+            dialect = csv.Sniffer().sniff(sample, delimiters=",;\t")
+        except csv.Error:
+            dialect = csv.excel
+        reader = csv.DictReader(handle, dialect=dialect)
+        if reader.fieldnames is None:
+            raise LedgerFormatError("Ledger file must contain a header row")
+        header_map = _map_headers(reader.fieldnames)
+        for row in reader:
+            account = row.get(header_map["account"], "").strip()
+            if not account:
+                # Ignore lines without account number: they are usually totals.
+                continue
+            debit = _parse_decimal(row.get(header_map["debit"], "0"))
+            credit = _parse_decimal(row.get(header_map["credit"], "0"))
+            date_value = None
+            if "date" in header_map:
+                date_value = _parse_date(row.get(header_map["date"], ""))
+            journal_value = None
+            if "journal" in header_map:
+                journal_value = row.get(header_map["journal"], "").strip() or None
+            description_value = None
+            if "description" in header_map:
+                description_value = row.get(header_map["description"], "").strip() or None
+            entries.append(
+                LedgerEntry(
+                    date=date_value,
+                    journal=journal_value,
+                    account=account,
+                    description=description_value,
+                    debit=debit,
+                    credit=credit,
+                )
+            )
+    return entries
+
+
+__all__ = ["LedgerEntry", "LedgerFormatError", "load_ledger"]

--- a/gl_reporting/mapping.py
+++ b/gl_reporting/mapping.py
@@ -1,0 +1,88 @@
+"""Mapping rules between general ledger accounts and reporting lines."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from typing import List, Optional, Sequence
+import csv
+
+
+@dataclass(frozen=True)
+class MappingRule:
+    """Associates an account pattern to a reporting category."""
+
+    pattern: str
+    category: str
+    label: Optional[str] = None
+    sign: int = 1
+
+    def matches(self, account: str) -> bool:
+        return fnmatch(account, self.pattern)
+
+    @property
+    def specificity(self) -> int:
+        return sum(1 for char in self.pattern if char not in {"*", "?"})
+
+
+class MappingTable:
+    """Ordered collection of mapping rules with helper methods."""
+
+    def __init__(self, rules: Sequence[MappingRule]):
+        # Sort once to avoid recomputing at lookup time. More specific rules first.
+        self._rules: List[MappingRule] = sorted(
+            rules, key=lambda rule: (-rule.specificity, rule.pattern)
+        )
+
+    def __iter__(self):  # pragma: no cover - simple iterator
+        return iter(self._rules)
+
+    def match(self, account: str) -> Optional[MappingRule]:
+        for rule in self._rules:
+            if rule.matches(account):
+                return rule
+        return None
+
+
+def _parse_sign(value: str) -> int:
+    cleaned = value.strip()
+    if not cleaned:
+        return 1
+    try:
+        numeric = int(cleaned)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Invalid sign value: {value!r}") from exc
+    if numeric not in {1, -1}:
+        raise ValueError(f"Sign must be 1 or -1, got {numeric}")
+    return numeric
+
+
+def load_mapping(path: str, encoding: str = "utf-8") -> MappingTable:
+    """Loads the mapping table from a CSV file.
+
+    The file must contain the columns ``pattern`` and ``category``. Optional
+    columns are ``label`` (a human readable description) and ``sign`` which allows
+    you to invert the sign of the amount (useful for revenue accounts recorded on
+    the credit side).
+    """
+
+    rules: List[MappingRule] = []
+    with open(path, "r", encoding=encoding, newline="") as handle:
+        reader = csv.DictReader(handle)
+        required = {"pattern", "category"}
+        if reader.fieldnames is None or not required.issubset(reader.fieldnames):
+            missing = required - set(reader.fieldnames or [])
+            raise RuntimeError(
+                "Mapping file must define columns: " + ", ".join(sorted(missing))
+            )
+        for row in reader:
+            pattern = row.get("pattern", "").strip()
+            category = row.get("category", "").strip()
+            if not pattern or not category:
+                continue
+            label = row.get("label", "").strip() or None
+            sign_value = _parse_sign(row.get("sign", "1"))
+            rules.append(MappingRule(pattern=pattern, category=category, label=label, sign=sign_value))
+    return MappingTable(rules)
+
+
+__all__ = ["MappingRule", "MappingTable", "load_mapping"]

--- a/gl_reporting/report.py
+++ b/gl_reporting/report.py
@@ -1,0 +1,179 @@
+"""Generate a management reporting from a general ledger and a mapping table."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Dict, Iterable, List, Optional
+import argparse
+import csv
+import sys
+
+from .ledger import LedgerEntry, load_ledger
+from .mapping import MappingRule, MappingTable, load_mapping
+
+
+TWO_PLACES = Decimal("0.01")
+
+
+@dataclass(frozen=True)
+class CategorisedEntry:
+    entry: LedgerEntry
+    category: str
+    rule: Optional[MappingRule]
+    amount: Decimal
+
+
+@dataclass
+class ReportResult:
+    totals: Dict[str, Decimal]
+    categorised_entries: List[CategorisedEntry]
+    default_category: str
+
+    @property
+    def unmapped_entries(self) -> List[CategorisedEntry]:
+        return [item for item in self.categorised_entries if item.rule is None]
+
+
+def _format_decimal(value: Decimal) -> str:
+    return str(value.quantize(TWO_PLACES, rounding=ROUND_HALF_UP))
+
+
+def aggregate_by_category(
+    entries: Iterable[LedgerEntry],
+    mapping: MappingTable,
+    default_category: str = "Non affecté",
+) -> ReportResult:
+    totals: Dict[str, Decimal] = {}
+    categorised: List[CategorisedEntry] = []
+    for entry in entries:
+        rule = mapping.match(entry.account)
+        if rule is None:
+            category = default_category
+            amount = entry.amount
+        else:
+            category = rule.category
+            amount = entry.amount * Decimal(rule.sign)
+        totals[category] = totals.get(category, Decimal("0")) + amount
+        categorised.append(
+            CategorisedEntry(entry=entry, category=category, rule=rule, amount=amount)
+        )
+    return ReportResult(totals=totals, categorised_entries=categorised, default_category=default_category)
+
+
+def build_report(
+    ledger_path: str,
+    mapping_path: str,
+    *,
+    default_category: str = "Non affecté",
+    encoding: str = "utf-8",
+) -> ReportResult:
+    entries = load_ledger(ledger_path, encoding=encoding)
+    mapping = load_mapping(mapping_path, encoding=encoding)
+    return aggregate_by_category(entries, mapping, default_category=default_category)
+
+
+def write_summary_csv(result: ReportResult, path: str, *, encoding: str = "utf-8") -> None:
+    with open(path, "w", encoding=encoding, newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["category", "amount"])
+        for category, amount in sorted(result.totals.items()):
+            writer.writerow([category, _format_decimal(amount)])
+
+
+def write_details_csv(result: ReportResult, path: str, *, encoding: str = "utf-8") -> None:
+    with open(path, "w", encoding=encoding, newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            [
+                "date",
+                "journal",
+                "account",
+                "description",
+                "debit",
+                "credit",
+                "amount",
+                "category",
+                "rule_label",
+            ]
+        )
+        for item in result.categorised_entries:
+            entry = item.entry
+            writer.writerow(
+                [
+                    entry.date.isoformat() if entry.date else "",
+                    entry.journal or "",
+                    entry.account,
+                    entry.description or "",
+                    _format_decimal(entry.debit),
+                    _format_decimal(entry.credit),
+                    _format_decimal(item.amount),
+                    item.category,
+                    item.rule.label if item.rule else "",
+                ]
+            )
+
+
+def print_summary(result: ReportResult, file=sys.stdout) -> None:
+    print("Catégorie".ljust(40) + "Montant", file=file)
+    print("-" * 55, file=file)
+    for category, amount in sorted(result.totals.items()):
+        print(category.ljust(40) + _format_decimal(amount), file=file)
+    if result.unmapped_entries:
+        print("\nComptes non affectés:", file=file)
+        for item in result.unmapped_entries:
+            entry = item.entry
+            line = f"  - {entry.account} : {entry.description or 'Sans libellé'}"
+            print(line, file=file)
+
+
+def _parse_arguments(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Génère un reporting à partir d'un grand livre et d'un mapping"
+    )
+    parser.add_argument("--ledger", required=True, help="Chemin vers le grand livre CSV")
+    parser.add_argument("--mapping", required=True, help="Chemin vers le mapping CSV")
+    parser.add_argument("--output", help="Chemin du fichier CSV de synthèse")
+    parser.add_argument("--details", help="Chemin du fichier CSV détaillant les écritures")
+    parser.add_argument(
+        "--default-category",
+        default="Non affecté",
+        help="Nom de la catégorie utilisée si aucune règle n'est trouvée",
+    )
+    parser.add_argument(
+        "--encoding",
+        default="utf-8",
+        help="Encodage des fichiers d'entrée et de sortie",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _parse_arguments(argv)
+    result = build_report(
+        args.ledger,
+        args.mapping,
+        default_category=args.default_category,
+        encoding=args.encoding,
+    )
+    if args.output:
+        write_summary_csv(result, args.output, encoding=args.encoding)
+    else:
+        print_summary(result)
+    if args.details:
+        write_details_csv(result, args.details, encoding=args.encoding)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CategorisedEntry",
+    "ReportResult",
+    "aggregate_by_category",
+    "build_report",
+    "print_summary",
+    "write_summary_csv",
+    "write_details_csv",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,65 @@
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from gl_reporting.ledger import LedgerFormatError, load_ledger
+from gl_reporting.mapping import MappingRule, MappingTable
+from gl_reporting.report import aggregate_by_category
+
+
+def test_load_ledger_handles_aliases_and_formats(tmp_path: Path) -> None:
+    csv_content = """Date;Journal;Compte;Libellé;Débit;Crédit\n01/01/2024;VT;701100;Vente;0;1500\n"""
+    file_path = tmp_path / "ledger.csv"
+    file_path.write_text(csv_content, encoding="utf-8")
+    entries = load_ledger(str(file_path), encoding="utf-8")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.date.year == 2024 and entry.date.month == 1 and entry.date.day == 1
+    assert entry.journal == "VT"
+    assert entry.account == "701100"
+    assert entry.description == "Vente"
+    assert entry.debit == Decimal("0")
+    assert entry.credit == Decimal("1500")
+
+
+def test_load_ledger_missing_columns_raises(tmp_path: Path) -> None:
+    csv_content = """Date;Libellé;Montant\n2024-01-01;Test;100\n"""
+    file_path = tmp_path / "invalid.csv"
+    file_path.write_text(csv_content, encoding="utf-8")
+    with pytest.raises(LedgerFormatError):
+        load_ledger(str(file_path), encoding="utf-8")
+
+
+def test_mapping_specificity() -> None:
+    table = MappingTable(
+        [
+            MappingRule(pattern="70*", category="CA générique", label=None, sign=-1),
+            MappingRule(pattern="706*", category="CA services", label=None, sign=-1),
+        ]
+    )
+    first_rule = table.match("706100")
+    assert first_rule is not None
+    assert first_rule.category == "CA services"
+
+
+def test_aggregate_by_category(tmp_path: Path) -> None:
+    ledger_content = """date,journal,account,description,debit,credit\n2024-01-01,VT,701100,Vente,0,1500\n2024-01-02,VT,706000,Prestations,0,500\n2024-01-03,AC,606100,Achat,200,0\n2024-01-04,OD,471000,A ventiler,100,0\n"""
+    ledger_path = tmp_path / "ledger.csv"
+    ledger_path.write_text(ledger_content, encoding="utf-8")
+
+    mapping = MappingTable(
+        [
+            MappingRule("706*", "CA prestations", "", -1),
+            MappingRule("70*", "CA marchandises", "", -1),
+            MappingRule("606*", "Charges achats", "", 1),
+        ]
+    )
+
+    entries = load_ledger(str(ledger_path))
+    result = aggregate_by_category(entries, mapping, default_category="Non ventilé")
+    assert result.totals["CA prestations"] == Decimal("500")
+    assert result.totals["CA marchandises"] == Decimal("1500")
+    assert result.totals["Charges achats"] == Decimal("200")
+    assert result.totals["Non ventilé"] == Decimal("100")
+    assert len(result.unmapped_entries) == 1


### PR DESCRIPTION
## Summary
- ajoute un parseur de grand livre CSV capable de reconnaître les principaux intitulés de colonnes
- met en place des règles de mapping et une CLI pour agréger les écritures en lignes de reporting
- fournit des exemples de fichiers, la documentation et des tests `pytest`

## Testing
- pytest
- python -m gl_reporting.report --ledger data/sample_ledger.csv --mapping data/sample_mapping.csv

------
https://chatgpt.com/codex/tasks/task_e_68d1588bd8248327b63ad86dd070c0c8